### PR TITLE
Add live grep sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nnoremap <silent><leader>ft :lua fzy.try(fzy.actions.lsp_tags, fzy.actions.buf_t
 nnoremap <silent><leader>fg :lua fzy.execute('git ls-files', fzy.sinks.edit_file)<CR>
 nnoremap <silent><leader>fq :lua fzy.actions.quickfix()<CR>
 nnoremap <silent><leader>f/ :lua fzy.actions.buf_lines()<CR>
-nnoremap <silent><leader>fl :lua fzy.execute('ag --nobreak --noheading .', fzy.sinks.edit_file)<CR>
+nnoremap <silent><leader>fl :lua fzy.execute('ag --nobreak --noheading .', fzy.sinks.edit_live_grep)<CR>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ nnoremap <silent><leader>ft :lua fzy.try(fzy.actions.lsp_tags, fzy.actions.buf_t
 nnoremap <silent><leader>fg :lua fzy.execute('git ls-files', fzy.sinks.edit_file)<CR>
 nnoremap <silent><leader>fq :lua fzy.actions.quickfix()<CR>
 nnoremap <silent><leader>f/ :lua fzy.actions.buf_lines()<CR>
+nnoremap <silent><leader>fl :lua fzy.execute('ag --nobreak --noheading .', fzy.sinks.edit_file)<CR>
 ```
 
 

--- a/doc/fzy.txt
+++ b/doc/fzy.txt
@@ -99,7 +99,7 @@ try(...)                                                             *fzy.try()*
       no LSP client/server is available - it falls back to ctags.
 
 
-sinks.edit_file                                           *fzy.sinks.edit_file*
+sinks.edit_file                                            *fzy.sinks.edit_file*
 
 
       A callback that can be used with |fzy.execute()|. It invokes `:e` on the
@@ -109,3 +109,20 @@ sinks.edit_file                                           *fzy.sinks.edit_file*
       >
           fzy.execute('git ls-files', fzy.sinks.edit_file)
 
+
+sinks.edit_live_grep                                  *fzy.sinks.edit_live_grep*
+
+
+      A callback that can be used with |fzy.execute()|. It parses the live
+      grep selection and invokes `:e +line-number` on the filename. The
+      selection format should have the following format:
+
+      {filename}:{line-number}:{search-preview}
+
+      Example usage with `ag`:
+      >
+          fzy.execute('ag --nobreak --noheading .', fzy.sinks.edit_live_grep)
+<
+      Example usage with `rg`:
+      >
+          fzy.execute('rg --no-heading --trim -nH .', fzy.sinks.edit_live_grep)

--- a/lua/fzy.lua
+++ b/lua/fzy.lua
@@ -48,6 +48,17 @@ function sinks.edit_file(selection)
 end
 
 
+function sinks.edit_live_grep(selection)
+  -- fzy returns search input if zero results found. This case is mapped to nil as well.
+  selection = string.match(selection, ".+:%d+:.+")
+  if selection then
+    local parts = vim.split(selection, ":")
+    local path, line = parts[1], parts[2]
+    vim.cmd("e +" .. line .. " " .. path)
+  end
+end
+
+
 -- Return a formatted path or name for a bufnr
 function M.format_bufname(bufnr)
   return vfn.fnamemodify(api.nvim_buf_get_name(bufnr), ':.')


### PR DESCRIPTION
@mfussenegger, this is basically your proposed snippet in #15. The additional string match enforces the expected selection format, namely `{filename} : {line-number} : {search-preview}`, and maps the search input to `nil` if zero results are found.

I have added usage examples for `ag` and `rg` to the documentation and tested both while working on finishing my personal Neovim config.

What do you think about adding this to the `main` branch?