### PR TITLE
Remove reference to vim.lsp.protocol

### DIFF
--- a/lua/fzy.lua
+++ b/lua/fzy.lua
@@ -1,6 +1,5 @@
 local api = vim.api
 local vfn = vim.fn
-local protocol = vim.lsp.protocol
 local M = {}
 
 local function fst(xs)
@@ -189,7 +188,7 @@ function M.actions.lsp_tags()
           table.insert(path, parent.name)
           parent = parent.__parent
         end
-        local kind = protocol.SymbolKind[item.kind]
+        local kind = vim.lsp.protocol.SymbolKind[item.kind]
         -- Omit the root if there are no non-container symbols on root level
         -- This is for example the case in Java where everything is inside a class
         -- In that case the class name is mostly noise


### PR DESCRIPTION
Indexing vim.lsp loads the entire LSP subsystem, which means loading fzy
also loads LSP, even if neither LSP nor the `lsp_tags` action are ever
used.

For reference, this reduces the loading time of `fzy.lua` from around 7ms to around 0.6ms on my 2017 Intel Mac.
