### PR TITLE
Split pickers out into nvim-qwahl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,35 @@
 # nvim-fzy
 
-Like [fzf.vim][1] but for [fzy][2] and neovim with Lua API.
+A `vim.ui.select` implementation for the [fzy][2] CLI.
 
 
 ## Installation
 
-- Requires Neovim >= 0.5
+- Requires Neovim (latest stable or nightly)
 - Install [fzy][2] and make sure it is in your `$PATH`.
 - nvim-fzy is a plugin. Install it like any other plugin:
   - If using [vim-plug][5]: `Plug 'mfussenegger/nvim-fzy'`
   - If using [packer.nvim][6]: `use 'mfussenegger/nvim-fzy'`
 
-
 ## Usage
+
+`nvim-fzy` provides the `vim.ui.select` implementation and a `execute` function
+to feed the output of commands to `fzy`.
 
 Create some mappings like this:
 
 ```vimL
 lua fzy = require('fzy')
 nnoremap <silent><leader>ff :lua fzy.execute('fd', fzy.sinks.edit_file)<CR>
-nnoremap <silent><leader>fb :lua fzy.actions.buffers()<CR>
-nnoremap <silent><leader>ft :lua fzy.try(fzy.actions.lsp_tags, fzy.actions.buf_tags)<CR>
 nnoremap <silent><leader>fg :lua fzy.execute('git ls-files', fzy.sinks.edit_file)<CR>
-nnoremap <silent><leader>fq :lua fzy.actions.quickfix()<CR>
-nnoremap <silent><leader>f/ :lua fzy.actions.buf_lines()<CR>
 nnoremap <silent><leader>fl :lua fzy.execute('ag --nobreak --noheading .', fzy.sinks.edit_live_grep)<CR>
 ```
-
 
 See `:help fzy` for more information
 
 ![demo](demo/demo.gif)
+
+To get additional pickers to jump to tags and other stuff, you can use it in combination with [nvim-qwahl](https://github.com/mfussenegger/nvim-qwahl)
 
 Enjoy
 

--- a/lua/fzy.lua
+++ b/lua/fzy.lua
@@ -78,6 +78,7 @@ M.actions = {}
 
 
 function M.actions.buf_lines()
+  vim.notify_once('fzy.actions.buf_lines will be removed. Use the nvim-qwahl plugin', vim.log.levels.WARN)
   local lines = api.nvim_buf_get_lines(0, 0, -1, true)
   local win = api.nvim_get_current_win()
   M.pick_one(lines, 'Lines> ', function(x) return x end, function(result, idx)
@@ -90,6 +91,7 @@ end
 
 
 function M.actions.buffers()
+  vim.notify_once('fzy.actions.buffers will be removed. Use the nvim-qwahl plugin', vim.log.levels.WARN)
   local bufs = vim.tbl_filter(
     function(b)
       return api.nvim_buf_is_loaded(b) and api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix'
@@ -174,6 +176,7 @@ end
 
 
 function M.actions.lsp_tags(opts)
+  vim.notify_once('fzy.actions.lsp_tags will be removed. Use the nvim-qwahl plugin', vim.log.levels.WARN)
   opts = opts or {}
   local params = vim.lsp.util.make_position_params()
   params.context = {
@@ -270,6 +273,7 @@ function M.actions.lsp_tags(opts)
 end
 
 function M.actions.buf_tags()
+  vim.notify_once('fzy.actions.buf_tags will be removed use the nvim-qwahl plugin', vim.log.levels.WARN)
   local bufname = api.nvim_buf_get_name(0)
   assert(vfn.filereadable(bufname), 'File to generate tags for must be readable')
   local ok, output = pcall(vfn.system, {
@@ -306,6 +310,7 @@ end
 
 
 function M.actions.quickfix()
+  vim.notify_once('fzy.actions.quickfix will be removed. Use the nvim-qwahl plugin', vim.log.levels.WARN)
   vim.cmd('cclose')
   local items = vfn.getqflist()
   M.pick_one(
@@ -422,11 +427,10 @@ end
 
 
 function M.setup()
-  if vim.ui then
-    function vim.ui.select(items, opts, on_choice)  -- luacheck: ignore 122
-      return M.pick_one(items, opts.prompt, opts.format_item, on_choice)
-    end
-  end
+  vim.notify_once(
+    'fzy.setup() became a no-op, fzy now registers itself as vim.ui.select provider by default',
+    vim.log.levels.WARN
+  )
 end
 
 return M

--- a/lua/fzy.lua
+++ b/lua/fzy.lua
@@ -118,6 +118,7 @@ end
 
 
 function M.actions.jumplist()
+  vim.notify_once('fzy.actions.jumplist will be removed. Use the nvim-qwahl plugin', vim.log.levels.WARN)
   local locations = vim.tbl_filter(
     function(loc) return api.nvim_buf_is_valid(loc.bufnr) end,
     vim.fn.getjumplist()[1]
@@ -159,6 +160,7 @@ end
 
 
 function M.actions.tagstack()
+  vim.notify_once('fzy.actions.tagstack will be removed. Use the nvim-qwahl plugin', vim.log.levels.WARN)
   local stack = vim.fn.gettagstack()
   M.pick_one(
     stack.items or {},

--- a/plugin/fzy.lua
+++ b/plugin/fzy.lua
@@ -1,0 +1,6 @@
+
+if vim.ui then
+  function vim.ui.select(items, opts, on_choice)  -- luacheck: ignore 122
+    return require('fzy').pick_one(items, opts.prompt, opts.format_item, on_choice)
+  end
+end


### PR DESCRIPTION
- Setup becomes a no-op, fzy registers itself as vim.ui.select provider
  by default
- All picker implementations that can be implemented on top of
  vim.ui.select will be moved to https://github.com/mfussenegger/nvim-qwahl
