### PR TITLE
Don't set `border` for float window

### DIFF
--- a/lua/fzy.lua
+++ b/lua/fzy.lua
@@ -65,7 +65,6 @@ function M.new_popup()
     col = math.floor((columns - width) * 0.5),
     width = width,
     height = height,
-    border = 'single',
   }
   local win = api.nvim_open_win(buf, true, opts)
   return win, buf


### PR DESCRIPTION
To have it use new (in nvim 0.11) `winborder` global
